### PR TITLE
Allow passing a block normally

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,13 @@ targets:
 require "json"
 require "crambda"
 
-def handler(event : JSON::Any, context : Crambda::Context)
+Crambda.run_handler do |event, context|
   pp context
-  JSON.parse("[1, 2]")
-end
-
-Crambda.run_handler(->handler(JSON::Any, Crambda::Context))
-```
-
-Where `Crambda.run_handler` expects a handler that takes a `JSON::Any` event
-and a `Context`, and returns a `JSON::Any` response:
-
-```crystal
-def self.run_handler(handler : Proc(JSON::Any, Context, JSON::Any))
-  # ...
+  [1, 2]
 end
 ```
 
-And `Context` is a class that looks like this:
+`Crambda.run_handler` expects a block that takes a `JSON::Any` event and a `Crambda::Context` and returns an object that implements `to_json`. The `Crambda::Context` is a class that looks like this:
 
 ```crystal
 class Context

--- a/src/crambda.cr
+++ b/src/crambda.cr
@@ -65,4 +65,8 @@ module Crambda
       end
     end
   end
+
+  def self.run_handler(&block : JSON::Any, Context -> T) forall T
+    run_handler block
+  end
 end


### PR DESCRIPTION
In addition to passing a `Proc` as a value, this PR allows us to pass a first-class block to `Crambda.run_handler`:

```crystal
Crambda.run_handler do |event, context|
  { foo: "bar", omg: "lol", wtf: 42 }
end
```

Notice that we don't even need to return a `JSON::Any` explicitly — we can pass anything that responds to `to_json`.